### PR TITLE
Removal of clom for python3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ def main():
         ],
         long_description=open('README').read(),
         install_requires=[
-            "clom==0.8.0a1",
             "requests==2.6.0",
         ],
     )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def main():
         ],
         long_description=open('README').read(),
         install_requires=[
-            "clom==0.7.5",
+            "clom==0.8.0a1",
             "requests==2.6.0",
         ],
     )

--- a/src/testing/elasticsearch.py
+++ b/src/testing/elasticsearch.py
@@ -44,6 +44,9 @@ class ElasticSearchServer(object):
         if cmd is None:
             es_check = Popen(['which', 'elasticsearch'], stdout=PIPE)
             cmd = es_check.stdout.read().strip()
+        if not cmd or len(cmd) == 0:
+            raise RuntimeError("Failed to find elasticsearch please add to PATH or provide location in cmd")
+
         self._cmd = cmd
 
         self._foreground = foreground

--- a/src/testing/elasticsearch.py
+++ b/src/testing/elasticsearch.py
@@ -5,8 +5,8 @@ import signal
 from shutil import rmtree
 from time import sleep
 from datetime import datetime
+from subprocess import Popen, PIPE
 
-from clom import clom
 import requests
 
 
@@ -42,7 +42,8 @@ class ElasticSearchServer(object):
             # elasticsearch terminated here when context exits
         """
         if cmd is None:
-            cmd = str(clom.which('elasticsearch').shell())
+            es_check = Popen(['which', 'elasticsearch'], stdout=PIPE)
+            cmd = es_check.stdout.read().strip()
         self._cmd = cmd
 
         self._foreground = foreground

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+requests


### PR DESCRIPTION
Would you consider removing clom?  The current version does not seem to support python 3 yet.  I tested this in both python 2.7 and 3.4.
